### PR TITLE
Bump image to `bitnami/kafka:3.5.1-debian-11-r21`

### DIFF
--- a/docker-compose-cluster.yml
+++ b/docker-compose-cluster.yml
@@ -12,7 +12,7 @@ volumes:
 services:
 ##Kafka 00    
   Kafka00Service:
-    image: bitnami/kafka:3.5.1-debian-11-r1
+    image: bitnami/kafka:3.5.1-debian-11-r21
     restart: unless-stopped
     container_name: Kafka00Container
     ports:
@@ -36,7 +36,7 @@ services:
       - "Kafka00:/bitnami/kafka"
 ##Kafka 01
   Kafka01Service:
-    image: bitnami/kafka:3.5.0-debian-11-r23
+    image: bitnami/kafka:3.5.1-debian-11-r21
     restart: always
     container_name: Kafka01Container
     ports:
@@ -60,7 +60,7 @@ services:
       - "Kafka01:/bitnami/kafka"
 ##Kafka 02
   Kafka02Service:
-    image: bitnami/kafka:3.5.0-debian-11-r23
+    image: bitnami/kafka:3.5.1-debian-11-r21
     restart: always
     container_name: Kafka02Container
     ports:

--- a/docker-compose-cluster.yml
+++ b/docker-compose-cluster.yml
@@ -30,6 +30,8 @@ services:
       - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=3 # https://cwiki.apache.org/confluence/display/KAFKA/KIP-115%3A+Enforce+offsets.topic.replication.factor+upon+__consumer_offsets+auto+topic+creation
       - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3
       - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=2
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
     networks:
       - kafka_network
     volumes:
@@ -54,6 +56,8 @@ services:
       - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=3 # https://cwiki.apache.org/confluence/display/KAFKA/KIP-115%3A+Enforce+offsets.topic.replication.factor+upon+__consumer_offsets+auto+topic+creation
       - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3
       - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=2
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
     networks:
       - kafka_network
     volumes:
@@ -78,6 +82,8 @@ services:
       - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=3 # https://cwiki.apache.org/confluence/display/KAFKA/KIP-115%3A+Enforce+offsets.topic.replication.factor+upon+__consumer_offsets+auto+topic+creation
       - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=3
       - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=2
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
     networks:
       - kafka_network
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,17 +7,21 @@ volumes:
 
 services:
   Kafka00Service:
-    image: bitnami/kafka:3.5.1-debian-11-r1
+    image: bitnami/kafka:3.5.1-debian-11-r21
     restart: always
     container_name: Kafka00Container
     ports:
       - '9094:9094'
     environment:
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@Kafka00Service:9093
+      - KAFKA_CFG_NODE_ID=0
       - ALLOW_PLAINTEXT_LISTENER=yes
       - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
       - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://Kafka00Service:9092,EXTERNAL://127.0.0.1:9094
       - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
     networks:
       - kafka_network
     volumes:


### PR DESCRIPTION
Removed env variable KAFKA_ENABLE_KRAFT. Instead, KRaft configuration will be detected if KAFKA_CFG_PROCESS_ROLES is provided


By default, the container will not configure neither Zookeeper mode or KRaft mode. IMPORTANT: Either KAFKA_CFG_PROCESS_ROLES or KAFKA_CFG_ZOOKEEPER_CONNECT must be configured for Apache Kafka to be started. The equivalent configuration to the deprecated KAFKA_ENABLE_KRAFT=true option would be setting KAFKA_CFG_PROCESS_ROLES=controller,broker. This change is especially aimed to support migrating from Zookeeper mode to KRaft mode. Once Zookeeper mode is fully removed we will default to a KRaft controller+broker mode. Once Zookeeper mode is fully removed we will default to a KRaft controller+broker mode

